### PR TITLE
chore: propose shell modules

### DIFF
--- a/checks/xinux-biosboot/default.nix
+++ b/checks/xinux-biosboot/default.nix
@@ -19,6 +19,7 @@ pkgs.testers.runNixOSTest {
         nixosModules.packagemanagers
         nixosModules.pipewire
         nixosModules.printing
+        nixosModules.shell
         nixosModules.xinux
         ./configuration.nix
       ];

--- a/checks/xinux-efiboot/default.nix
+++ b/checks/xinux-efiboot/default.nix
@@ -19,6 +19,7 @@ pkgs.testers.runNixOSTest {
         nixosModules.packagemanagers
         nixosModules.pipewire
         nixosModules.printing
+        nixosModules.shell
         nixosModules.xinux
         ./configuration.nix
       ];

--- a/modules/nixos/shell/default.nix
+++ b/modules/nixos/shell/default.nix
@@ -27,6 +27,14 @@ in
     {
       # command not found for nix
       nix-index.enable = true;
+
+      # prettier terminal prompt
+      programs.starship = {
+        enable = true;
+        settings = {
+          battery.disabled = true;
+        };
+      };
     }
 
     # Shell preferences

--- a/modules/nixos/shell/default.nix
+++ b/modules/nixos/shell/default.nix
@@ -1,0 +1,166 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib;
+let
+  cfg = config.modules.shell;
+in
+{
+  options.modules.shell = with types; {
+    type = mkOption {
+      type = enum [
+        "zsh"
+        "bash"
+        # TODO: "fish"
+      ];
+      default = "zsh";
+      description = "Shell type to user's liking.";
+    };
+
+    direnv = mkEnableOption "direnv support";
+  };
+
+  config = lib.mkMerge [
+    # Defaults
+    {
+      # command not found for nix
+      nix-index.enable = true;
+    }
+
+    # Shell preferences
+    (lib.mkIf (cfg.type == "bash") {
+      programs = {
+        bash = {
+          completion.enable = true;
+          vteIntegration = true;
+        };
+
+        nix-index.enableBashIntegration = true;
+      };
+    })
+
+    (lib.mkIf (cfg.type == "zsh") {
+      programs = {
+        # Installing zsh for system
+        zsh = {
+          enable = true;
+          vteIntegration = true;
+          enableCompletion = true;
+
+          # History file
+          histFile = 5000;
+          histSize = 5000;
+
+          # Autosuggestions
+          autosuggestions = {
+            enable = true;
+            highlight = "fg=gray";
+          };
+
+          # ZSH Syntax Highlighting
+          syntaxHighlighting = {
+            enable = true;
+            highlighters = [
+              "main"
+              "brackets"
+              "pattern"
+            ];
+            patterns = {
+              "rm -rf *" = "fg=white,bold,bg=red";
+            };
+            styles = {
+              default = "none";
+              unknown-token = "fg=gray,underline";
+              reserved-word = "fg=cyan,bold";
+              suffix-alias = "fg=green,underline";
+              global-alias = "fg=green,bold";
+              precommand = "fg=green,underline";
+              commandseparator = "fg=blue,bold";
+              autodirectory = "fg=green,underline";
+              path = "bold";
+              path_pathseparator = "";
+              path_prefix_pathseparator = "";
+              globbing = "fg=blue,bold";
+              history-expansion = "fg=blue,bold";
+              command-substitution = "none";
+              command-substitution-delimiter = "fg=magenta,bold";
+              process-substitution = "none";
+              process-substitution-delimiter = "fg=magenta,bold";
+              single-hyphen-option = "fg=green";
+              double-hyphen-option = "fg=green";
+              back-quoted-argument = "none";
+              back-quoted-argument-delimiter = "fg=blue,bold";
+              single-quoted-argument = "fg=yellow";
+              double-quoted-argument = "fg=yellow";
+              dollar-quoted-argument = "fg=yellow";
+              rc-quote = "fg=magenta";
+              dollar-double-quoted-argument = "fg=magenta,bold";
+              back-double-quoted-argument = "fg=magenta,bold";
+              back-dollar-quoted-argument = "fg=magenta,bold";
+              assign = "none";
+              redirection = "fg=blue,bold";
+              comment = "fg=black,bold";
+              named-fd = "none";
+              numeric-fd = "none";
+              arg0 = "fg=cyan";
+              bracket-error = "fg=red,bold";
+              bracket-level-1 = "fg=blue,bold";
+              bracket-level-2 = "fg=green,bold";
+              bracket-level-3 = "fg=magenta,bold";
+              bracket-level-4 = "fg=yellow,bold";
+              bracket-level-5 = "fg=cyan,bold";
+              cursor-matchingbracket = "standout";
+            };
+          };
+
+          # Extra Features
+          setOptions = [
+            "AUTO_CD"
+            "BEEP"
+            "HIST_BEEP"
+            "HIST_EXPIRE_DUPS_FIRST"
+            "HIST_FIND_NO_DUPS"
+            "HIST_IGNORE_ALL_DUPS"
+            "HIST_IGNORE_DUPS"
+            "HIST_REDUCE_BLANKS"
+            "HIST_SAVE_NO_DUPS"
+            "HIST_VERIFY"
+            "INC_APPEND_HISTORY"
+            "INTERACTIVE_COMMENTS"
+            "MAGIC_EQUAL_SUBST"
+            "NO_NO_MATCH"
+            "NOTIFY"
+            "NUMERIC_GLOB_SORT"
+            "PROMPT_SUBST"
+            "SHARE_HISTORY"
+          ];
+        };
+
+        direnv.enableZshIntegration = true;
+        nix-index.enableZshIntegration = true;
+      };
+
+      # All users default shell must be zsh
+      users.defaultUserShell = pkgs.zsh;
+
+      # System configurations
+      environment = {
+        shells = with pkgs; [ zsh ];
+        pathsToLink = [ "/share/zsh" ];
+      };
+    })
+
+    # Direnv
+    (lib.mkIf cfg.direnv {
+      # Automatic flake devShell loading
+      programs.direnv = {
+        enable = true;
+        silent = true;
+        loadInNixShell = false;
+        nix-direnv.enable = true;
+      };
+    })
+  ];
+}

--- a/modules/nixos/shell/default.nix
+++ b/modules/nixos/shell/default.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   config,
   lib,
   ...
@@ -25,14 +26,16 @@ in
   config = lib.mkMerge [
     # Defaults
     {
-      # command not found for nix
-      nix-index.enable = true;
+      programs = {
+        # command not found for nix
+        nix-index.enable = true;
 
-      # prettier terminal prompt
-      programs.starship = {
-        enable = true;
-        settings = {
-          battery.disabled = true;
+        # prettier terminal prompt
+        starship = {
+          enable = true;
+          settings = {
+            battery.disabled = true;
+          };
         };
       };
     }
@@ -58,13 +61,12 @@ in
           enableCompletion = true;
 
           # History file
-          histFile = 5000;
           histSize = 5000;
 
           # Autosuggestions
           autosuggestions = {
             enable = true;
-            highlight = "fg=gray";
+            highlightStyle = "fg=gray";
           };
 
           # ZSH Syntax Highlighting

--- a/modules/nixos/shell/module.yml
+++ b/modules/nixos/shell/module.yml
@@ -1,0 +1,21 @@
+---
+name: Shell
+id: modules.shell
+flake: xinux-modules
+description: "Shell with its configurations."
+version: 0.0.1
+icon:
+  type: system
+  path: application-x-executable-symbolic
+
+options:
+  - label: "Shell Type"
+    id: modules.pipewire.enable
+    description: "Choose shell to your liking."
+    type: !switch
+      default: true
+  - label: "Jack"
+    id: services.pipewire.jack.enable
+    description: "Enable Jack support."
+    type: !switch
+      default: false

--- a/modules/nixos/shell/module.yml
+++ b/modules/nixos/shell/module.yml
@@ -2,6 +2,8 @@
 name: Shell
 id: modules.shell
 flake: xinux-modules
+unique_groups:
+  - shell
 description: "Shell with its configurations."
 version: 0.0.1
 icon:
@@ -10,12 +12,15 @@ icon:
 
 options:
   - label: "Shell Type"
-    id: modules.pipewire.enable
+    id: modules.shell.type
     description: "Choose shell to your liking."
-    type: !switch
-      default: true
-  - label: "Jack"
-    id: services.pipewire.jack.enable
-    description: "Enable Jack support."
+    type: !enum
+      default: zsh
+      options:
+        zsh: ZSH
+        bash: Bash
+  - label: "Direnv"
+    id: modules.shell.direnv
+    description: "Enable direnv integration for the shell."
     type: !switch
       default: false

--- a/modules/nixos/xinux/hardware.nix
+++ b/modules/nixos/xinux/hardware.nix
@@ -46,8 +46,7 @@ in
     # if the list includes intel in the list
     (lib.mkIf (builtins.elem "intel" cfg.gpu) {
       # GPU (Intel)
-      graphics = {
-        enable = lib.mkDefault true;
+      hardware.graphics = {
         extraPackages = with pkgs; [
           vpl-gpu-rt
           intel-media-driver


### PR DESCRIPTION
Giving our users the following options:

- Pick preconfigured flavor of their favorite shell: zsh and bash at the moment.
- Enable direnv integration for better development experience.
- Starship for everything

ZSH includes:
- Syntax highlighter
- Autosuggestions
- Better defaults
- Direnv integraiton
- nix-index integration

Bash includes:
- Simple defaults
- Completion
- nix-index integration 